### PR TITLE
update apt::source usage to remove deprecation warning log spam

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -28,11 +28,13 @@ class sensu::repo::apt {
       location    => $url,
       release     => 'sensu',
       repos       => $sensu::repo,
-      include_src => false,
-      key         => $sensu::repo_key_id,
-      key_source  => $sensu::repo_key_source,
-      before   => Package['sensu'],
-      notify   => Exec['apt-update'],
+      include     => { 'src' => false },
+      key         => {
+        'id'     => $sensu::repo_key_id,
+        'source' => $sensu::repo_key_source,
+      },
+      before      => Package['sensu'],
+      notify      => Exec['apt-update'],
     }
 
     exec {

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": [
     { "name": "lwf/remote_file", "version_requirement": ">= 1.0.0 <2.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 1.8.0 <3.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 2.1.0 <3.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" }
   ]
 }


### PR DESCRIPTION
@fessyfoo this should reduce the amount of warnings on our error logs dashboard